### PR TITLE
Create Docker container for webapp

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,3 @@
-webapp
+webapp/node_modules
 .git
 .idea

--- a/Dockerfile-webapp
+++ b/Dockerfile-webapp
@@ -1,0 +1,9 @@
+FROM qfarm/webapp
+
+ADD webapp /webapp
+
+RUN cd /webapp && \
+    npm install && \
+    npm run build:prod
+
+CMD ["http-server", "/webapp/dist/", "-d", "-p 9000"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,11 @@ server:
     - redis:redis
   ports:
     - "8080:8080"
+webapp:
+  build: .
+  dockerfile: Dockerfile-webapp
+  ports:
+    - "9000:9000"
 websocket:
   build: .
   dockerfile: Dockerfile-ws

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -43,6 +43,8 @@
   },
   "dependencies": {
     "angular2": "2.0.0-beta.8",
+    "awesome-typescript-loader": "^0.16.2",
+    "core-js": "^2.2.1",
     "es6-promise": "^3.1.2",
     "es6-shim": "^0.33.3",
     "es7-reflect-metadata": "^1.6.0",

--- a/webapp/src/app/app.ts
+++ b/webapp/src/app/app.ts
@@ -20,11 +20,13 @@ import { Config } from './config/config';
     { path: '/',      name: 'Entry', component: Entry, useAsDefault: true },
     { path: '/build/:repoName/', component: Build, name: 'Last Build' },
     { path: '/build/:repoName/:buildId/', component: Build, name: 'Build' },
-    { path: '/build/:repoName/:buildId/:file/', component: Build, name: 'Build - File View' }
+    { path: '/build/:repoName/:buildId/:file/', component: Build, name: 'Build - File View' },
     { path: '/config', component: Config, name: 'Config - Get QFarm Configuration' }
 ])
 export class App {
     name = 'Quality Farm';
+    buildsList: any;
+    userRepos: any;
 
     user : string;
 

--- a/webapp/webpack.prod.config.js
+++ b/webapp/webpack.prod.config.js
@@ -124,7 +124,7 @@ module.exports = {
       // Tslint loader support for *.ts files
       //
       // See: https://github.com/wbuchwalter/tslint-loader
-      {test: /\.ts$/, loader: 'tslint-loader', exclude: [helpers.root('node_modules')]},
+//      {test: /\.ts$/, loader: 'tslint-loader', exclude: [helpers.root('node_modules')]},
 
       // Source map loader support for *.js files
       // Extracts SourceMaps for source files that as added as sourceMappingURL comment.
@@ -266,7 +266,7 @@ module.exports = {
     // NOTE: To debug prod builds uncomment //debug lines and comment //prod lines
     new UglifyJsPlugin({
       // beautify: true, //debug
-      // mangle: false, //debug
+       mangle: false, //debug
       // dead_code: false, //debug
       // unused: false, //debug
       // deadCode: false, //debug
@@ -282,7 +282,8 @@ module.exports = {
       beautify: false,//prod
 
       // mangle: { screw_ie8 : true }, //prod
-      mangle: {
+/*
+        mangle: {
         screw_ie8: true,
         except: [
           'App',
@@ -334,6 +335,7 @@ module.exports = {
           'I18nSelectPipe'
         ] // Needed for uglify RouterLink problem
       }, // prod
+ */
       compress: {screw_ie8: true}, //prod
       comments: false //prod
     }),


### PR DESCRIPTION
Fixes #5 

It is still required to have `docker` in `/etc/hosts/` that is pointing to the location of the API server.
- [x] create Docker image with npm modules pre-installed
- [x] remove link between webapp and server in `docker-compose
- [x] move Docker image to qfarm Hub user
